### PR TITLE
change: Change return value when no face is detected

### DIFF
--- a/facer/face_detection/retinaface.py
+++ b/facer/face_detection/retinaface.py
@@ -634,7 +634,12 @@ def batch_detect(net: nn.Module, images: torch.Tensor, threshold: float = 0.5):
             image_ids.append(image_id)
 
     if len(rects) == 0:
-        return dict()
+        return {
+            'rects': torch.Tensor().to(img.device),
+            'points': torch.Tensor().to(img.device),
+            'scores': torch.Tensor().to(img.device),
+            'image_ids': torch.Tensor().to(img.device),
+        }
 
     return {
         'rects': torch.stack(rects, dim=0).to(img.device),


### PR DESCRIPTION
When a face is detected, an empty dict is returned, so the user must count the number of faces and at the same time determine if it is an empty dict or a `KeyError`.

With this change, it is now possible to simply count the number of faces detected