### PR TITLE
fix timm deprecation warning

### DIFF
--- a/facer/farl/model.py
+++ b/facer/farl/model.py
@@ -8,7 +8,7 @@ import torch.nn.functional as F
 from torch import nn
 import torch.utils.checkpoint as checkpoint
 import numpy as np
-from timm.models.layers import trunc_normal_, DropPath
+from timm.layers import trunc_normal_, DropPath
 
 
 class Bottleneck(nn.Module):


### PR DESCRIPTION
Since timm 1.0.11 the following warning emerges (introduced by https://github.com/huggingface/pytorch-image-models/commit/fad45388012a441bb3a084a20220b6d6f2bf47bc):

```
/conda/envs/teeth/lib/python3.12/site-packages/timm/models/layers/__init__.py:48: FutureWarning: Importing from timm.models.
layers is deprecated, please import via timm.layers
```

This pull request would eliminate the warning.